### PR TITLE
Feature/claim issues

### DIFF
--- a/contracts/src/Tombola.sol
+++ b/contracts/src/Tombola.sol
@@ -37,7 +37,7 @@ contract Tombola is VRFConsumerBaseV2Plus {
      */
     mapping(address => uint256) public userClaim;
 
-    // The income amount of the round day -> accumulated amount x round 
+    // The income amount of the round day -> accumulated amount x round
     mapping(uint256 => uint256) public incomeRoundAmount;
 
     /**
@@ -74,7 +74,7 @@ contract Tombola is VRFConsumerBaseV2Plus {
     // Cannot exceed VRFV2Wrapper.getConfig().maxNumWords.
     uint32 numWords = 1;
 
-    // The commission amount accumulated  
+    // The commission amount accumulated
     uint256 public commissionAmount;
 
     uint256 private randomNumber;
@@ -208,8 +208,9 @@ contract Tombola is VRFConsumerBaseV2Plus {
             return;
         }
         uint256 balanceWithoutCommissionRound = (incomeRoundAmount[currentDay] *
-            (uint256(100)) - uint256(commission))) / uint256(100);
-        uint256 amountToDistributeFinal = (balanceWithoutCommissionRound  /
+            (uint256(100)) -
+            uint256(commission)) / uint256(100);
+        uint256 amountToDistributeFinal = balanceWithoutCommissionRound /
             nPlaysNumberDay[currentDay][guessNumber];
         for (uint256 i = 0; i < nPlaysNumberDay[currentDay][guessNumber]; ) {
             userClaim[
@@ -219,9 +220,10 @@ contract Tombola is VRFConsumerBaseV2Plus {
                 i++;
             }
         }
-        commisionAmount += incomeRoundAmount[currentDay] - balanceWithoutCommissionRound;
+        commissionAmount +=
+            incomeRoundAmount[currentDay] -
+            balanceWithoutCommissionRound;
         incomeRoundAmount[currentDay] = 0;
-
     }
 
     function claim() public payable {
@@ -238,7 +240,7 @@ contract Tombola is VRFConsumerBaseV2Plus {
      * @dev Function for the owner to withdraw the balance of the Tombola contract.
      */
     function withdraw() external onlyOwner {
-        payable(msg.sender).transfer(commisionAmount);
+        payable(msg.sender).transfer(commissionAmount);
     }
 
     /**
@@ -246,7 +248,7 @@ contract Tombola is VRFConsumerBaseV2Plus {
      * @param _address The address to which the balance will be transferred.
      */
     function withdrawTo(address _address) external onlyOwner {
-        payable(_address).transfer(commisionAmount);
+        payable(_address).transfer(commissionAmount);
     }
 
     /**

--- a/contracts/src/Tombola.sol
+++ b/contracts/src/Tombola.sol
@@ -38,6 +38,11 @@ contract Tombola is VRFConsumerBaseV2Plus {
     mapping(address => uint256) public userClaim;
 
     /**
+     * @notice The address of the automation.
+     */
+    address public automationAddress;
+
+    /**
      * @notice The commission percentage charged by the contract.
      */
     uint64 public commission;
@@ -67,6 +72,14 @@ contract Tombola is VRFConsumerBaseV2Plus {
     uint32 numWords = 1;
 
     uint256 private randomNumber;
+
+    modifier onlyOwnerOrAutomationForward() {
+        require(
+            msg.sender == owner() || msg.sender == automationAddress,
+            "Only owner or automation forward"
+        );
+        _;
+    }
 
     //uint256 private requestId;
 
@@ -302,7 +315,7 @@ contract Tombola is VRFConsumerBaseV2Plus {
      */
     function generatePseudoRandom(
         bool enableNativePayment
-    ) external onlyOwner returns (uint256 requestId) {
+    ) external onlyOwnerOrAutomationForward returns (uint256 requestId) {
         //TODO: UNCOMMENT FOR PRODUCTION
         uint256 currentDay = (block.timestamp - 1 days) / 1 days;
         //TODO
@@ -358,6 +371,10 @@ contract Tombola is VRFConsumerBaseV2Plus {
         require(s_requests[_requestId].exists, "request not found");
         RequestStatus memory request = s_requests[_requestId];
         return (request.fulfilled, request.randomWords);
+    }
+
+    function setAutomationAddress(address _automationAddress) public onlyOwner {
+        automationAddress = _automationAddress;
     }
 
     function setCallbackGasLimit(uint32 _callbackGasLimit) public onlyOwner {


### PR DESCRIPTION
Add two variables : 
- commissionAmount to accumulate the protocol rewards, 
- incomeRoundAmount (mapping day --> amount) : The amount is incremented per each `play` call. All the income is saved here. The map kept the amount x day. This variable was became mapping because if a user call play before the generate number is call and after the day of the play this income will not be taken into account. I want to say the issue is taking place in the middle of generate random and the play of the current day. Ex. In Argentina is 22 hours and the `generateRandomNumber` is not call yet, but the user call to play so the variable income(if not mapping) is incremented but the distribute reset it. In the case this variable is mapping the reste is taking place in the proper day so the income keep the amount for the proper day. 